### PR TITLE
Added 204 as ok result for POST messages to QRS

### DIFF
--- a/qrsInteract.js
+++ b/qrsInteract.js
@@ -159,7 +159,7 @@ var qrsInteract = function QRSInteractMain(hostname, portNumber, virtualProxyPre
                     bufferResponse = Buffer.concat([bufferResponse, data]);
                 })
                 .on('end', function () {
-                    if (statusCode == 200 || statusCode == 201) {
+                    if (statusCode == 200 || statusCode == 201 || statusCode == 204) {
                         var jsonResponse = "";
                         if (bufferResponse.length != 0) {
                             try {


### PR DESCRIPTION
Some POST endpoints of the QRS API  return empty results when successful, for example /qrs/userdirectoryconnector/syncuserdirectories

These come out as errors using the old code. 
Added 204 as an acceptable result, avoiding unintended errors in apps using qrs-interact for POSTing messages.