### PR TITLE
Added error handling to Get method

### DIFF
--- a/qrsInteract.js
+++ b/qrsInteract.js
@@ -116,7 +116,10 @@ var qrsInteract = function QRSInteractMain(hostname, portNumber, virtualProxyPre
                         reject("Received error code: " + statusCode + '::' + responseString);
                     }
                 });
+            }).on('error', (e) => {
+                reject('Error calling QRS: ' + JSON.stringify(e, null, 2));
             });
+        
             req.end();
         });
     };


### PR DESCRIPTION
Without this new error handling, it was difficult to properly handle for example a case where a Get call was done to a QRS that was not (for some reason) responding. 
The new error handling rejects the promise, and the calling application can deal with the error as needed.

Thinking about it... the same error handling should probably be added also to Put and Post methods... One thing at a time though.