### PR TITLE
Added additional TLS configuration options

### DIFF
--- a/qrsInteractFactory.js
+++ b/qrsInteractFactory.js
@@ -107,6 +107,11 @@ var qrsInteract = function QRSInteract(inputConfig) {
         throw "Please use 'certFile' and 'keyFile' OR 'pfxFile' and 'passphrase' in your config for setting up your certificates.";
     }
 
+    if (localConfig['minTlsVersion'] != null) requestDefaultParams.minVersion = localConfig.minTlsVersion;
+    if (localConfig['maxTlsVersion'] != null) requestDefaultParams.maxVersion = localConfig.maxTlsVersion;
+    if (localConfig['honorCipherOrder'] != null) requestDefaultParams.honorCipherOrder = localConfig.honorCipherOrder;
+    if (localConfig['ciphers'] != null) requestDefaultParams.ciphers = localConfig.ciphers;
+
     var qrsInteractInstance = new qrsInteractMain(localConfig.hostname, localConfig.portNumber, localConfig.virtualProxyPrefix, xrfkeyParam, requestDefaultParams);
     return qrsInteractInstance;
 }


### PR DESCRIPTION
Allows additional options (minVersion, maxVersion, honorCipherOrderand ciphers) to be passed through to the TLS library.

I was unable to connect to our Qlik server via qrs-Interact as we have a very strict TLS implementation (so we generally get A/A+ on [SSLTest](https://www.ssllabs.com/ssltest/), which is part of our corporate security standard.

For my case, setting minVersion and maxVersion was sufficient but I've also added the options "honor cipher order" and "ciphers" which would allow a user of qrs-Interact more flexibility to ensure that it can connect to Qlik.